### PR TITLE
Help developers get started

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ target/
 dev*.db
 pip-selfcheck.json
 bin
+man
 include

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
-install: "pip install -r requirements.txt"
+install: "make deps"
 script:
   - make test
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ deps: bin/python
 
 .PHONY: run
 run:
-	python polycules.py
+	bin/python polycules.py
 
 .PHONY: test
 test:
-	flake8 --config=.flake8
-	nosetests --with-coverage --cover-erase --verbosity=2 --cover-package=polycules,model,migrations.hashify
+	bin/flake8 --config=.flake8
+	bin/nosetests --with-coverage --cover-erase --verbosity=2 --cover-package=polycules,model,migrations.hashify

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@
 [![polycul.es](https://img.shields.io/website-up-down-green-red/https/polycul.es.svg)](https://polycul.es)
 
 Graphing polyamorous relationships with force directed layouts.
+
+## Development
+
+You will need to install Python and virtualenv using whatever package manager your operating system uses.  Then you can setup, run and test the application as follows:
+
+1. Create a new virtualenv environment by running `make`
+2. Install dependencies by running `make deps`
+3. Run the application by running `make run` and opening http://localhost:5000/ in a browser
+4. Run the tests by running `make test`

--- a/polycules.py
+++ b/polycules.py
@@ -167,4 +167,5 @@ def delete_polycule(polycule_id):
 
 
 if __name__ == '__main__':
+    migrate()
     app.run()


### PR DESCRIPTION
Run the migrations on startup, use the virtualenv version of binaries to fix dependencies, and add some documentation to the README file on how to get started.