### PR TITLE
validate received graph against json schema

### DIFF
--- a/polycules.py
+++ b/polycules.py
@@ -1,7 +1,9 @@
 import base64
 import os
 import sqlite3
+import json
 from contextlib import closing
+from jsonschema import validate
 
 from flask import (
     Flask,
@@ -166,6 +168,13 @@ def save_existing_polycule(polycule_id):
 @app.route('/save', methods=['POST'])
 def save_new_polycule():
     """ Save a created polycule. """
+    try:
+        with open('schema.json') as json_data:
+            schema = json.load(json_data)
+        validate(json.loads(request.form['graph']), schema)
+    except:
+        return render_template('error.jinja2',
+                               error='The submitted graph could not be parsed')
     try:
         polycule = Polycule.create(
             g.db,

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ PyYAML==3.12
 requests==2.12.1
 six==1.10.0
 Werkzeug==0.11.4
+jsonschema==2.6.0

--- a/schema.json
+++ b/schema.json
@@ -31,10 +31,15 @@
             "type": "number"
           },
           "r": {
-            "type": "integer"
+            "type": ["integer", "string"],
+            "description": "Radius"
           },
           "index": {
             "type": "integer"
+          },
+          "dashed": {
+            "type": "boolean",
+            "optional": true
           }
         },
         "additionalProperties": false
@@ -45,6 +50,22 @@
       "items": {
         "type": "object",
         "properties": {
+                        "sourceText": {
+                "type": "string",
+                "optional": true
+              },
+              "dashed": {
+                "type": "boolean",
+                "optional": true
+              },
+              "targetText": {
+                "type": "string",
+                "optional": true
+              },
+              "centerText": {
+                "type": "string",
+                "optional": true
+              },
           "source": {
             "type": "object",
             "properties": {
@@ -112,7 +133,7 @@
             "additionalProperties": false
           },
           "strength": {
-            "type": "integer"
+            "type": ["integer", "string"]
           }
         },
         "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -1,4 +1,48 @@
 {
+  "$schema": "http://json-schema.org/draft-0.4/schema#",
+  "definitions": {
+    "node": {
+      "type": "object",
+      "properties": {
+        "weight": {
+          "type": "integer"
+        },
+        "x": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        },
+        "y": {
+          "type": "number"
+        },
+        "px": {
+          "type": "number"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "py": {
+          "type": "number"
+        },
+        "r": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "Radius"
+        },
+        "index": {
+          "type": "integer"
+        },
+        "dashed": {
+          "type": "boolean",
+          "optional": true
+        }
+      },
+      "additionalProperties": false
+    }
+  },
   "type": "object",
   "properties": {
     "lastId": {
@@ -7,42 +51,7 @@
     "nodes": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "weight": {
-            "type": "integer"
-          },
-          "x": {
-            "type": "number"
-          },
-          "name": {
-            "type": "string"
-          },
-          "y": {
-            "type": "number"
-          },
-          "px": {
-            "type": "number"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "py": {
-            "type": "number"
-          },
-          "r": {
-            "type": ["integer", "string"],
-            "description": "Radius"
-          },
-          "index": {
-            "type": "integer"
-          },
-          "dashed": {
-            "type": "boolean",
-            "optional": true
-          }
-        },
-        "additionalProperties": false
+        "$ref": "#/definitions/node"
       }
     },
     "links": {
@@ -50,90 +59,33 @@
       "items": {
         "type": "object",
         "properties": {
-                        "sourceText": {
-                "type": "string",
-                "optional": true
-              },
-              "dashed": {
-                "type": "boolean",
-                "optional": true
-              },
-              "targetText": {
-                "type": "string",
-                "optional": true
-              },
-              "centerText": {
-                "type": "string",
-                "optional": true
-              },
+          "sourceText": {
+            "type": "string",
+            "optional": true
+          },
+          "dashed": {
+            "type": "boolean",
+            "optional": true
+          },
+          "targetText": {
+            "type": "string",
+            "optional": true
+          },
+          "centerText": {
+            "type": "string",
+            "optional": true
+          },
           "source": {
-            "type": "object",
-            "properties": {
-              "weight": {
-                "type": "integer"
-              },
-              "x": {
-                "type": "number"
-              },
-              "name": {
-                "type": "string"
-              },
-              "y": {
-                "type": "number"
-              },
-              "px": {
-                "type": "number"
-              },
-              "id": {
-                "type": "integer"
-              },
-              "py": {
-                "type": "number"
-              },
-              "r": {
-                "type": "integer"
-              },
-              "index": {
-                "type": "integer"
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/definitions/node"
           },
           "target": {
-            "type": "object",
-            "properties": {
-              "weight": {
-                "type": "integer"
-              },
-              "x": {
-                "type": "number"
-              },
-              "name": {
-                "type": "string"
-              },
-              "y": {
-                "type": "number"
-              },
-              "px": {
-                "type": "number"
-              },
-              "id": {
-                "type": "integer"
-              },
-              "py": {
-                "type": "number"
-              },
-              "r": {
-                "type": "integer"
-              },
-              "index": {
-                "type": "integer"
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/definitions/node"
           },
           "strength": {
-            "type": ["integer", "string"]
+            "type": [
+              "integer",
+              "string"
+            ]
           }
         },
         "additionalProperties": false

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,123 @@
+{
+  "type": "object",
+  "properties": {
+    "lastId": {
+      "type": "integer"
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "weight": {
+            "type": "integer"
+          },
+          "x": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "y": {
+            "type": "number"
+          },
+          "px": {
+            "type": "number"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "py": {
+            "type": "number"
+          },
+          "r": {
+            "type": "integer"
+          },
+          "index": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "object",
+            "properties": {
+              "weight": {
+                "type": "integer"
+              },
+              "x": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              },
+              "y": {
+                "type": "number"
+              },
+              "px": {
+                "type": "number"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "py": {
+                "type": "number"
+              },
+              "r": {
+                "type": "integer"
+              },
+              "index": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "target": {
+            "type": "object",
+            "properties": {
+              "weight": {
+                "type": "integer"
+              },
+              "x": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              },
+              "y": {
+                "type": "number"
+              },
+              "px": {
+                "type": "number"
+              },
+              "id": {
+                "type": "integer"
+              },
+              "py": {
+                "type": "number"
+              },
+              "r": {
+                "type": "integer"
+              },
+              "index": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          },
+          "strength": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/test_validation.py
+++ b/test_validation.py
@@ -3,9 +3,6 @@ from jsonschema import validate
 import json
 
 
-DATABASE = 'dev.db'
-
-
 def validatejson(body):
     with open('schema.json') as json_data:
         schema = json.load(json_data)

--- a/test_validation.py
+++ b/test_validation.py
@@ -35,6 +35,27 @@ class SingleNode(TestCase):
         '''))
 
 
+class SingleNodeExtraParamaters(TestCase):
+    def test(self):
+        with self.assertRaises(Exception):
+            validatejson('''
+{"lastId":2,
+        "nodes":[
+        {"id":1,
+        "name":"Alice",
+        "x":477.1,
+        "y":297.6,
+        "r":12,
+        "index":0,
+        "weight":0,
+        "px":477.2,
+        "py":297.4,
+        "watcher":"Eve"}
+        ],
+        "links":[]}
+            ''')
+
+
 class SingleNodeFullParamaters(TestCase):
     def test(self):
         self.assertIsNone(validatejson(

--- a/test_validation.py
+++ b/test_validation.py
@@ -1,0 +1,188 @@
+from unittest import TestCase
+from jsonschema import validate
+import json
+
+
+DATABASE = 'dev.db'
+
+
+def validatejson(body):
+    with open('schema.json') as json_data:
+        schema = json.load(json_data)
+    return validate(json.loads(body), schema)
+
+
+class EmptyHash(TestCase):
+    def test(self):
+        self.assertIsNone(validatejson('{}'))
+
+
+class SingleNode(TestCase):
+    def test(self):
+        self.assertIsNone(validatejson('''{"lastId":2,
+        "nodes":[
+        {"id":1,
+        "name":"Alice",
+        "x":477.1,
+        "y":297.6,
+        "r":12,
+        "index":0,
+        "weight":0,
+        "px":477.2,
+        "py":297.4}
+        ],
+        "links":[]}
+        '''))
+
+
+class SingleNodeFullParamaters(TestCase):
+    def test(self):
+        self.assertIsNone(validatejson(
+            '''
+{"lastId":2,
+  "nodes":[
+  {
+    "id":1,
+    "name":"Alice",
+    "x":480.2,
+    "y":249.7,
+    "r":"4",
+    "index":0,
+    "weight":0,
+    "px":480.1,
+    "py":249.9,
+    "dashed":true
+  }
+  ],
+  "links":[]
+}
+            '''
+        ))
+
+
+class TestLink(TestCase):
+    def test(self):
+        self.assertIsNone(validatejson(
+            '''
+{
+   "links" : [
+      {
+         "strength" : 10,
+         "target" : {
+            "py" : 250,
+            "index" : 1,
+            "name" : "Bob",
+            "y" : 250,
+            "px" : 480,
+            "weight" : 1,
+            "x" : 480,
+            "r" : 12,
+            "id" : 2
+         },
+         "source" : {
+            "index" : 0,
+            "name" : "Alice",
+            "y" : 250,
+            "px" : 480,
+            "py" : 250,
+            "x" : 480,
+            "r" : 12,
+            "id" : 1,
+            "weight" : 1
+         }
+      }
+   ],
+   "lastId" : 2,
+  "nodes" : [
+      {
+         "py" : 250,
+         "px" : 480,
+         "y" : 250,
+         "index" : 0,
+         "name" : "Alice",
+         "weight" : 1,
+         "id" : 1,
+         "r" : 12,
+         "x" : 480
+      },
+      {
+         "weight" : 1,
+         "x" : 480,
+         "id" : 2,
+         "r" : 12,
+         "py" : 250,
+         "y" : 250,
+         "index" : 1,
+         "name" : "Bob",
+         "px" : 480
+      }
+   ]
+}
+            '''
+        ))
+
+
+class TestLinkFullParamaters(TestCase):
+    def test(self):
+        self.assertIsNone(validatejson(
+            '''
+{
+   "lastId" : 2,
+   "nodes" : [
+      {
+         "px" : 506.708606373103,
+         "y" : 286.523952566997,
+         "name" : "Alice",
+         "x" : 506.787452218671,
+         "r" : 12,
+         "index" : 0,
+         "weight" : 1,
+         "py" : 286.416448430355,
+         "id" : 1
+      },
+      {
+         "x" : 453.212547781329,
+         "px" : 453.291393626897,
+         "y" : 213.476047433002,
+         "name" : "Bob",
+         "r" : 12,
+         "index" : 1,
+         "weight" : 1,
+         "py" : 213.583551569644,
+         "id" : 2
+      }
+   ],
+   "links" : [
+      {
+         "targetText" : "bob",
+         "centerText" : "center",
+         "dashed" : true,
+         "sourceText" : "alice",
+         "target" : {
+            "y" : 213.476047433002,
+            "px" : 453.291393626897,
+            "x" : 453.212547781329,
+            "name" : "Bob",
+            "r" : 12,
+            "index" : 1,
+            "py" : 213.583551569644,
+            "weight" : 1,
+            "id" : 2
+         },
+         "source" : {
+            "py" : 286.416448430355,
+            "weight" : 1,
+            "id" : 1,
+            "name" : "Alice",
+            "px" : 506.708606373103,
+            "y" : 286.523952566997,
+            "x" : 506.787452218671,
+            "r" : 12,
+            "index" : 0
+         },
+         "strength" : "5"
+      }
+   ]
+}
+            '''
+        ))

--- a/validate_db.py
+++ b/validate_db.py
@@ -1,0 +1,19 @@
+# Validate every row in the database to make sure the graph is valid JSON
+
+from jsonschema import validate
+import json
+import sqlite3
+
+
+DATABASE = 'dev.db'
+
+
+def validatejson(body):
+    with open('schema.json') as json_data:
+        schema = json.load(json_data)
+    return validate(json.loads(body), schema)
+
+
+db = sqlite3.connect(DATABASE)
+for row in db.execute('SELECT graph, hash FROM polycules'):
+    print(row[1], validatejson(row[0]))


### PR DESCRIPTION
Validates the graph being saved to make sure that it is actually json and validate it using a jsonschema.

I've not added a check against the size of the graph as per #7 but I could do.  The limit is 10^9 characters according to the sqlite spec (unless you override at runtime or have an old sqlite version).